### PR TITLE
#4: Add full static typing

### DIFF
--- a/aioresult/__init__.py
+++ b/aioresult/__init__.py
@@ -9,3 +9,9 @@ from aioresult._src import (
     TaskFailedException, TaskNotDoneException, FutureSetAgainException
 )
 from aioresult._wait import wait_all, wait_any, results_to_channel
+
+__all__ = [
+    "ResultBase", "ResultCapture", "Future", "TaskFailedException", "TaskNotDoneException",
+    "FutureSetAgainException",
+    "wait_all", "wait_any", "results_to_channel",
+]

--- a/aioresult/_aio.py
+++ b/aioresult/_aio.py
@@ -7,47 +7,81 @@
 The reason for defining these, rather than just using anyio (which already supports both Trio and
 wrappers for asyncio) is to allow use of aioresult with Trio even when anyio is not installed.
 """
+from typing import (
+    AsyncContextManager, Awaitable, Callable, Protocol, TypeVar, Union, TYPE_CHECKING,
+)
+from typing_extensions import TypeVarTuple, Unpack
 
 import asyncio
-from typing import Union
 import sniffio
+import sys
+
+
+RetT = TypeVar("RetT")
+T_contra = TypeVar("T_contra", contravariant=True)
+ArgsT = TypeVarTuple("ArgsT")
+
+
+if not TYPE_CHECKING and hasattr(sys, 'building_aioresult_docs'):
+    # If building Sphinx docs, unconditionally import so that we get nice unions in type hints.
+    import trio
+    import anyio.abc
+    import anyio.streams.memory
+    Nursery = Union[trio.Nursery, anyio.abc.TaskGroup]
+    Event = Union[trio.Event, asyncio.Event]
+    SendChannel = Union[trio.MemorySendChannel, anyio.streams.memory.MemoryObjectSendStream]
+else:
+    # Define the interfaces we need from either package.
+
+    class CancelScope(Protocol):
+        """A Trio or anyio CancelGroup. Required only for Nursery's attribute."""
+        def cancel(self) -> None:
+            ...
+
+    class Nursery(Protocol):
+        """A Trio Nursery or anyio TaskGroup."""
+        @property
+        def cancel_scope(self) -> CancelScope:
+            """We only need read-only access."""
+
+        def start_soon(
+            self,
+            func: Callable[[Unpack[ArgsT]], Awaitable[object]], /,
+            *args: Unpack[ArgsT],
+        ) -> None:
+            ...
+
+        # This can't be typed yet.
+        async def start(self, func: Callable[..., Awaitable[RetT]], *args: object) -> RetT:
+            ...
+
+    class Event(Protocol):
+        """A Trio or asyncio Event."""
+        def is_set(self) -> bool:
+            ...
+
+        async def wait(self) -> object:
+            ...
+
+
+    class SendChannel(Protocol[T_contra]):
+        """A trio MemorySendChannel or anyio MemoryObjectSendStream."""
+        async def send(self, value: T_contra, /) -> None:
+            ...
+
+        def close(self) -> None:
+            ...
 
 
 try:
     import trio
-
-    try:
-        import anyio
-
-        # Both trio and anyio are installed.
-        Nursery = Union[trio.Nursery, anyio.abc.TaskGroup]
-        Event = Union[trio.Event, asyncio.Event]
-        SendChannel = Union[trio.MemorySendChannel, anyio.streams.memory.MemoryObjectSendStream]
-    except ImportError:
-        # Only Trio is installed.
-        anyio = None
-        Nursery = trio.Nursery
-        Event = trio.Event
-        SendChannel = trio.MemorySendChannel
-
 except ImportError:
-    # No Trio
-    trio = None
-
-    try:
-        import anyio
-
-        # Only anyio is installed.
-        Nursery = anyio.abc.TaskGroup
-        Event = asyncio.Event
-        SendChannel = anyio.streams.memory.MemoryObjectSendStream
-
-    except ImportError:
-        # Neither Trio nor anyio! Do not raise an error, though aioresult won't be much use.
-        anyio = None
-        Nursery = None
-        Event = None
-        SendChannel = None
+    # Will only be used if user code imports trio.
+    trio = None  # type: ignore
+try:
+    import anyio
+except ImportError:
+    anyio = None  # type: ignore
 
 
 def create_event() -> Event:
@@ -61,7 +95,7 @@ def create_event() -> Event:
         raise RuntimeError(f"Unknown async library {sniffed}")
 
 
-def open_nursery() -> Nursery:
+def open_nursery() -> AsyncContextManager[Nursery]:
     """Opens a Trio Nursery or anyio TaskGroup."""
     sniffed = sniffio.current_async_library()
     if sniffed == "trio":

--- a/aioresult/_aio.py
+++ b/aioresult/_aio.py
@@ -63,6 +63,9 @@ else:
         async def wait(self) -> object:
             ...
 
+        def set(self) -> object:
+            ...
+
 
     class SendChannel(Protocol[T_contra]):
         """A trio MemorySendChannel or anyio MemoryObjectSendStream."""

--- a/aioresult/_aio.py
+++ b/aioresult/_aio.py
@@ -8,7 +8,7 @@ The reason for defining these, rather than just using anyio (which already suppo
 wrappers for asyncio) is to allow use of aioresult with Trio even when anyio is not installed.
 """
 from typing import (
-    AsyncContextManager, Awaitable, Callable, Protocol, TypeVar, Union, TYPE_CHECKING,
+    Any, AsyncContextManager, Awaitable, Callable, Protocol, TypeVar, Union, TYPE_CHECKING, cast,
 )
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -43,7 +43,8 @@ else:
         """A Trio Nursery or anyio TaskGroup."""
         @property
         def cancel_scope(self) -> CancelScope:
-            """We only need read-only access."""
+            # We only need read-only access.
+            ...
 
         def start_soon(
             self,
@@ -53,7 +54,7 @@ else:
             ...
 
         # This can't be typed yet.
-        async def start(self, func: Callable[..., Awaitable[RetT]], *args: object) -> RetT:
+        async def start(self, func: Callable[..., Awaitable[RetT]], /, *args: object) -> RetT:
             ...
 
     class Event(Protocol):
@@ -76,16 +77,16 @@ else:
         def close(self) -> None:
             ...
 
-
 try:
     import trio
 except ImportError:
-    # Will only be used if user code imports trio.
-    trio = None  # type: ignore
+    # It's fine if trio/anyio is not installed, it should never be accessed.
+    # Suppress errors about this being undefined, or None checks
+    trio = cast(Any, None)
 try:
     import anyio
 except ImportError:
-    anyio = None  # type: ignore
+    anyio = cast(Any, None)
 
 
 def create_event() -> Event:

--- a/aioresult/_aio.py
+++ b/aioresult/_aio.py
@@ -27,9 +27,10 @@ if not TYPE_CHECKING and hasattr(sys, 'building_aioresult_docs'):
     import trio
     import anyio.abc
     import anyio.streams.memory
+    T = TypeVar("T")
     Nursery = Union[trio.Nursery, anyio.abc.TaskGroup]
     Event = Union[trio.Event, asyncio.Event]
-    SendChannel = Union[trio.MemorySendChannel, anyio.streams.memory.MemoryObjectSendStream]
+    SendChannel = Union[trio.MemorySendChannel[T], anyio.streams.memory.MemoryObjectSendStream[T]]
 else:
     # Define the interfaces we need from either package.
 

--- a/aioresult/_src.py
+++ b/aioresult/_src.py
@@ -2,7 +2,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE or the copy at https://www.boost.org/LICENSE_1_0.txt
 
-from typing import Any, Awaitable, Callable, Generic, Optional, Tuple, TypeVar
+from typing import Any, Awaitable, Callable, Generic, Optional, Tuple, TypeVar, cast
 
 from typing_extensions import TypeVarTuple, Unpack
 
@@ -11,6 +11,7 @@ from aioresult._aio import *
 
 ResultT = TypeVar("ResultT")
 ArgsT = TypeVarTuple("ArgsT")
+_UNSET: Any = cast(Any, object())
 
 
 class FutureSetAgainException(Exception):
@@ -85,10 +86,10 @@ class ResultBase(Generic[ResultT]):
     """
     def __init__(self) -> None:
         self._done_event = create_event()
-        self._result: Optional[ResultT] = None
+        self._result: ResultT = _UNSET
         self._exception: Optional[BaseException] = None
 
-    def result(self) -> object:
+    def result(self) -> ResultT:
         """Returns the captured result of the task.
 
         :return: The value returned by the task.
@@ -100,6 +101,7 @@ class ResultBase(Generic[ResultT]):
             raise TaskNotDoneException(self)
         if self._exception is not None:
             raise TaskFailedException(self) from self._exception
+        assert self._result is not _UNSET
         return self._result
 
     def exception(self) -> Optional[BaseException]:

--- a/aioresult/_src.py
+++ b/aioresult/_src.py
@@ -246,13 +246,18 @@ class ResultCapture(ResultBase[ResultT], Generic[ResultT]):
         nursery.start_soon(rc.run)
         return rc
 
-    def __init__(self, routine, *args, suppress_exception: bool = False):
+    def __init__(
+        self,
+        routine: Callable[..., Awaitable[ResultT]],
+        *args: object,
+        suppress_exception: bool = False,
+    ) -> None:
         super().__init__()
         self._routine = routine
         self._args = args
         self._suppress_exception = suppress_exception
 
-    async def run(self, **kwargs) -> None:
+    async def run(self, **kwargs: Any) -> None:
         """Runs the routine and captures its result.
 
         This is where the magic of :class:`ResultCapture` happens ... except it's not very magical
@@ -287,21 +292,25 @@ class ResultCapture(ResultBase[ResultT], Generic[ResultT]):
             raise  # Allowed the exception to propagate into user nursery
 
     @property
-    def routine(self):
+    def routine(self) -> Callable[..., Awaitable[ResultT]]:
         """The routine whose result will be captured. This is the ``routine`` argument that was
         passed to the constructor or :meth:`start_soon()`."""
         return self._routine
 
     @property
-    def args(self):
+    def args(self) -> Tuple[object, ...]:
         """The arguments passed to the routine whose result will be captured. This is the ``args``
         argument that was passed to the constructor or :meth:`start_soon()`."""
         return self._args
 
     @classmethod
     def capture_start_and_done_results(
-        cls, run_nursery: Nursery, routine, *args, start_nursery: Optional[Nursery] = None
-    ):
+        cls,
+        run_nursery: Nursery,
+        routine: Callable[..., Awaitable[ResultT]],
+        *args: Any,
+        start_nursery: Optional[Nursery] = None,
+    ) -> Tuple['ResultCapture[Any]', 'ResultCapture[ResultT]']:
         """Captures both the startup and completion result of a task.
 
         The first return value represents whether the task has finished starting yet (i.e., whether it

--- a/aioresult/_src.py
+++ b/aioresult/_src.py
@@ -172,7 +172,7 @@ class Future(ResultBase[ResultT], Generic[ResultT]):
        see the documentation for that class for the inherited methods.
     """
 
-    def set_result(self, result: ResultT):
+    def set_result(self, result: ResultT) -> None:
         """Sets the result of the future to the given value.
 
         After calling this method, later calls to :meth:`ResultBase.result()` will return the value

--- a/aioresult/_wait.py
+++ b/aioresult/_wait.py
@@ -10,7 +10,7 @@ from aioresult._src import ResultBase
 ResultBaseT = TypeVar("ResultBaseT", bound=ResultBase[Any])
 
 
-async def wait_all(results: Iterable[ResultBase[Any]]) -> None:
+async def wait_all(results: Iterable[ResultBase[object]]) -> None:
     """Waits until all tasks are done.
 
     The implementation is extremely simple: it just iterates over the parameter and calls

--- a/aioresult/_wait.py
+++ b/aioresult/_wait.py
@@ -7,7 +7,7 @@ from aioresult._aio import *
 from aioresult._src import ResultBase
 
 
-ResultT = TypeVar("ResultT")
+ResultBaseT = TypeVar("ResultBaseT", bound=ResultBase[Any])
 
 
 async def wait_all(results: Iterable[ResultBase[Any]]) -> None:
@@ -24,7 +24,7 @@ async def wait_all(results: Iterable[ResultBase[Any]]) -> None:
         await r.wait_done()
 
 
-async def wait_any(results: Iterable[ResultBase[ResultT]]) -> ResultBase[ResultT]:
+async def wait_any(results: Iterable[ResultBaseT]) -> ResultBaseT:
     """Waits until one of the tasks is complete, and returns that object.
 
     Note that it is possible that, when this function returns, more than one of the tasks has
@@ -35,9 +35,9 @@ async def wait_any(results: Iterable[ResultBase[ResultT]]) -> ResultBase[ResultT
     :return: One of the objects in ``result``.
     :raise RuntimeError: If ``results`` is empty.
     """
-    first_result: Optional[ResultBase[ResultT]] = None
+    first_result: Optional[ResultBaseT] = None
 
-    async def wait_one(result: ResultBase[ResultT]) -> None:
+    async def wait_one(result: ResultBaseT) -> None:
         nonlocal first_result
         await result.wait_done()
         if first_result is None:
@@ -55,8 +55,8 @@ async def wait_any(results: Iterable[ResultBase[ResultT]]) -> ResultBase[ResultT
 
 
 async def results_to_channel(
-    results: Iterable[ResultBase[ResultT]],
-    channel: SendChannel[ResultBase[ResultT]],
+    results: Iterable[ResultBaseT],
+    channel: SendChannel[ResultBaseT],
     close_on_complete: bool = True,
 ) -> None:
     """Waits for :class:`ResultBase` tasks to complete, and sends them to an async channel.
@@ -86,7 +86,7 @@ async def results_to_channel(
         would be interrupted anyway.
     """
 
-    async def wait_one(result: ResultBase[ResultT]) -> None:
+    async def wait_one(result: ResultBaseT) -> None:
         await result.wait_done()
         await channel.send(result)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,10 @@ nitpicky = True
 nitpick_ignore = [
     # Format is ("sphinx reference type", "string"), e.g.:
     ("py:obj", "bytes-like"),
+    ("py:class", "aioresult._src.ResultT"),
+    ("py:class", "aioresult._wait.ResultBaseT"),
+    ("py:obj", "aioresult._src.ResultT"),
+    ("py:class", "ArgsT"),
 ]
 autodoc_inherit_docstrings = False
 default_role = "obj"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,9 @@ import sys
 # So autodoc can import our package
 sys.path.insert(0, os.path.abspath('../..'))
 
+# Set an attribute, so aioresult._aio knows that we're building docs.
+sys.building_aioresult_docs = True
+
 # Warn about all references to unknown targets
 nitpicky = True
 # Except for these ones, which we expect to point to unknown targets:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,8 @@ disallow_incomplete_defs = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
+
+[tool.pyright]
+include = ["aioresult/", "tests/type_tests.py"]
+pythonVersion = "3.9"
+typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,10 @@ license = {file = "LICENSE"}
 authors = [{name = "Arthur Tacca"}]
 readme = "README.rst"
 requires-python = ">=3.9"
-dependencies = ["sniffio>=1.0.0"]
+dependencies = [
+    "sniffio>=1.0.0",
+    "typing_extensions>=4.1.0",  # First version with TypeVarTuple/Unpack
+]
 
 keywords = ["async", "anyio", "trio", "result", "future", "nursery", "taskgroup"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tests = ["pytest", "coverage", "trio", "anyio", "exceptiongroup; python_version 
 
 [tool.mypy]
 python_version = "3.9"
-files = ["aioresult/", "tests/type_tests.py"]
+files = ["aioresult/", "tests/"]
 
 strict = true
 local_partial_types = true
@@ -64,6 +64,6 @@ disallow_untyped_decorators = true
 disallow_untyped_defs = true
 
 [tool.pyright]
-include = ["aioresult/", "tests/type_tests.py"]
+include = ["aioresult/", "tests/"]
 pythonVersion = "3.9"
 typeCheckingMode = "strict"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,22 @@ Documentation = "https://aioresult.readthedocs.io/en/v1.0/overview.html"
 [project.optional-dependencies]
 docs = ["sphinx>=6.1", "sphinxcontrib-trio", "sphinx_rtd_theme", "trio", "anyio"]
 tests = ["pytest", "coverage", "trio", "anyio", "exceptiongroup; python_version < '3.11'"]
+
+[tool.mypy]
+python_version = "3.9"
+files = ["aioresult/", "tests/type_tests.py"]
+
+strict = true
+local_partial_types = true
+warn_unused_ignores = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_return_any = true
+
+disallow_any_expr = false
+disallow_any_generics = true
+disallow_any_unimported = true
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -1,4 +1,5 @@
 """Run as part of type checking, not at runtime."""
+# pyright: reportUnusedVariable=false
 from aioresult._aio import (
     Nursery as NurseryProto,
     CancelScope as CancelScopeProto,

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -1,5 +1,9 @@
 """Run as part of type checking, not at runtime."""
 # pyright: reportUnusedVariable=false
+from typing import List
+from typing_extensions import assert_type
+
+from aioresult import ResultCapture
 from aioresult._aio import (
     Nursery as NurseryProto,
     CancelScope as CancelScopeProto,
@@ -26,3 +30,14 @@ def check_anyio_protocols(
     nursery: NurseryProto = task_group
     cancel_scope: CancelScopeProto = task_group.cancel_scope
     send_channel: SendChannelProto[bool] = send
+
+
+async def sample_func(a: int, b: str) -> List[str]:
+    return []
+
+
+async def check_resultcapture_start_soon(nursery: NurseryProto) -> None:
+    ResultCapture.start_soon(nursery, sample_func, 1)  # type: ignore
+    ResultCapture.start_soon(nursery, sample_func, 1, 'two', False)  # type: ignore
+    result = ResultCapture.start_soon(nursery, sample_func, 1, 'two')
+    assert_type(result.result(), List[str])

--- a/tests/type_tests.py
+++ b/tests/type_tests.py
@@ -1,0 +1,27 @@
+"""Run as part of type checking, not at runtime."""
+from aioresult._aio import (
+    Nursery as NurseryProto,
+    CancelScope as CancelScopeProto,
+    SendChannel as SendChannelProto,
+)
+
+from anyio.abc import TaskGroup
+from anyio.streams.memory import MemoryObjectSendStream
+import trio
+
+
+def check_trio_protocols(trio_nursery: trio.Nursery, send: trio.MemorySendChannel[bool]) -> None:
+    """Check Trio's classes satisfy our protocols."""
+    nursery: NurseryProto = trio_nursery
+    cancel_scope: CancelScopeProto = trio_nursery.cancel_scope
+    send_channel: SendChannelProto[bool] = send
+
+
+def check_anyio_protocols(
+    task_group: TaskGroup,
+    send: MemoryObjectSendStream[bool],
+) -> None:
+    """Check Anyio's classes satisfy our protocols."""
+    nursery: NurseryProto = task_group
+    cancel_scope: CancelScopeProto = task_group.cancel_scope
+    send_channel: SendChannelProto[bool] = send


### PR DESCRIPTION
This adds static types for the whole package. 
* `_aio` now uses protocols, but switches back to the existing unions if building docs. 
* I didn't make `ResultCapture` generic with respect to the positional arguments, so `ResultCapture.__init__`, `run()`, `routine`, `args` and `capture_start_and_done_results()` all have loose types. You wouldn't get errors but the checker isn't going to verify anything either. I could make it generic over those args, but the task-status passing still wouldn't work.
* `start_soon()` and the return type is fully checked though, which is probably what most people will be using.
