### PR TITLE
Add py.typed marker file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.dynamic]
 version = {attr = "aioresult._version.__version__"}
 
+[tool.setuptools]
+include-package-data = true
+
 [project]
 name = "aioresult"
 dynamic = ["version"]


### PR DESCRIPTION
Adds the `py.typed` marker file, so type checkers know that the annotations are actually used for type hints. Sorry I forgot this, must have only tested locally before - this only affects things in `site-packages.